### PR TITLE
Update iOS header path - RN 0.40

### DIFF
--- a/ios/RNNewRelic/RNNewRelic.h
+++ b/ios/RNNewRelic/RNNewRelic.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 #import <NewRelicAgent/NewRelic.h>
 
 @interface RNNewRelic : NSObject <RCTBridgeModule>


### PR DESCRIPTION
For the breaking change in RN 0.40.0 "iOS native headers moved". 
