### PR TITLE
Upgrade New Relic Android agent to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ In your project level `build.gradle`:
 ```
 dependencies {
 	...
-	classpath "com.newrelic.agent.android:agent-gradle-plugin:5.6.+"
+	classpath "com.newrelic.agent.android:agent-gradle-plugin:5.11.+"
 	...
  }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,6 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.newrelic.agent.android:android-agent:5.6.+'
+    compile 'com.newrelic.agent.android:android-agent:5.11.+'
     compile 'com.facebook.react:react-native:+' //from node_modules
 }


### PR DESCRIPTION
+ update installation instructions for Android in README.

This changes the Android New Relic agent version from 5.6.* to 5.11.*.

Versions > 5.8.0 include support for tracking HTTP requests made using the OkHttp3 library, which React Native upgraded to in version 0.27 (https://github.com/facebook/react-native/commit/6bbaff2944dafd6fa7e5b77ef46dece0ec2c9983).

However, I'm wondering if a better approach might be to remove the agent from the plugin entirely and make the user have to include it themselves.  This would allow users to use whichever version of the agent they want to.  Given that users already have to include the agent Gradle plugin themselves, and  the versions of the Gradle plugin & the agent itself have to match, I don't think it would be that much of a big deal to make this change.  What do you think?