### PR TITLE
Update Android compileSdkVersion to 25.0.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,8 +12,8 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 16

--- a/ios/RNNewRelic.xcodeproj/project.pbxproj
+++ b/ios/RNNewRelic.xcodeproj/project.pbxproj
@@ -219,6 +219,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../../../ios/Pods/**",
+					"$(SRCROOT)/../../../ios/NewRelicAgent.framework/Versions/A/Headers/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LIBRARY_SEARCH_PATHS = "";
@@ -236,6 +237,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../../../ios/Pods/**",
+					"$(SRCROOT)/../../../ios/NewRelicAgent.framework/Versions/A/Headers/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LIBRARY_SEARCH_PATHS = "";

--- a/ios/RNNewRelic/RNNewRelic.h
+++ b/ios/RNNewRelic/RNNewRelic.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModule.h>
-#import <NewRelicAgent/NewRelic.h>
+#import <NewRelic.h>
 
 @interface RNNewRelic : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
Fixes the following error:
`> A problem occurred configuring project ':react-native-newrelic'.
      > The SDK Build Tools revision (23.0.3) is too low for project ':react-native-newrelic'. Minimum required is 25.0.0`

Issue:
https://github.com/wix/react-native-newrelic/issues/16

