### PR TITLE
Add missing import for android setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ dependencies {
 Add `new RNNewRelicPackage()` to your list of packages in `getPackages()` in `MainApplication.java` :
 
 ``` java
+import com.wix.rnnewrelic.RNNewRelicPackage;
+
 @Override
 public List<ReactPackage> getPackages() {
   return Arrays.<ReactPackage>asList(... new RNNewRelicPackage());


### PR DESCRIPTION
Hi,

I noticed that for the package to work on android there was missing an import in the README file.

Cheers,

Enrique.