### PR TITLE
Adds support for linking NewRelic iOS manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,15 @@ More to come!
 npm install react-native-newrelic --save
 ```
 ## iOS 
-#### 1. Install New RelicAgent in your project as a pod
+#### 1. Install New RelicAgent in your project
+##### Option 1 (Using Cocoapods):
 In the Podfile for your project, add the following line:
 `pod 'NewRelicAgent'`
 Make sure Xcode is closed and run: `pod install`
+
+or
+
+##### Option 2 (Link it [manually](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-ios/installation/ios-manual-installation#configuration))
 
 #### 2. Add the project to Xcode
 In the project navigator:

--- a/ios/RNNewRelic.xcodeproj/project.pbxproj
+++ b/ios/RNNewRelic.xcodeproj/project.pbxproj
@@ -214,7 +214,7 @@
 		7B3424411CCF990C00FEBAEC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../../../ios/Frameworks";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../react-native/React/**",
@@ -231,7 +231,7 @@
 		7B3424421CCF990C00FEBAEC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "";
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../../../ios/Frameworks";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../react-native/React/**",


### PR DESCRIPTION
This PR adds support for linking the NewRelic iOS dependency manually instead of using Cocoapods.
